### PR TITLE
facebook,googleでのユーザー新規登録とログイン

### DIFF
--- a/app/assets/javascripts/_sign.js
+++ b/app/assets/javascripts/_sign.js
@@ -2,5 +2,7 @@ $(function(){
   $(window).load(function () {
     $(".error:contains('blank')").css('display', 'none');
     $(".error:contains('short')").css('display', 'none');
+    $(".error:contains('match')").css('display', 'none');
+    $(".error:contains('already')").css('display', 'none');
   });
 });

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,9 @@ class ApplicationController < ActionController::Base
                                                         :last_name_kana,
                                                         :birth_year,
                                                         :birth_month,
-                                                        :birth_day
+                                                        :birth_day,
+                                                        :uid,
+                                                        :provider
                                                       ])
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,42 +1,30 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
-  def google_oauth2
-    @user = User.find_for_google_oauth2(request.env["omniauth.auth"])
- 
-     if @user.persisted?
-       flash[:notice] = I18n.t "devise.omniauth_callbacks.success",
-                               :kind => "Google"
-       sign_in_and_redirect @user, :event => :authentication
-     else
-       session["devise.google_data"] = request.env["omniauth.auth"]
-       redirect_to new_user_registration_url
-     end
-   end
-
-  def failure
-    redirect_to root_path
-  end
-
-
-
-  def facebook
-    callback_for(:facebook)
-  end
-
   def facebook
     callback_from :facebook
   end
+
+  def google_oauth2
+    callback_from :google
+  end
+
+  private
+
   def callback_from(provider)
     provider = provider.to_s
- 
     @user = User.find_for_oauth(request.env['omniauth.auth'])
- 
+
     if @user.persisted?
       flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: provider.capitalize)
       sign_in_and_redirect @user, event: :authentication
     else
-      session["devise.#{provider}_data"] = request.env['omniauth.auth']
-      redirect_to new_user_registration_url
+      session[:nickname] = @user.nickname
+      session[:email] = @user.email
+      session[:password] = @user.password
+      session[:provider] = @user.provider
+      session[:uid] = @user.uid
+      redirect_to sns_path
     end
   end
+
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,6 +7,25 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def sms
   end
 
+  def sns
+    @user = User.new(
+      nickname: session[:nickname],
+      email: session[:email],
+      password: session[:password],
+      password_confirmation: session[:password],
+      uid: session[:uid],
+      provider: session[:provider]
+      )
+  end
+
+  # def new
+
+  # end
+
+  def create
+    super
+  end
+
   # GET /resource/sign_up
   # def new
   #   @user = User.new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
+         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook google_oauth2]
   
   validates :nickname,
     presence: { message: "ニックネームを入力してください" }
@@ -36,18 +36,6 @@ class User < ApplicationRecord
     presence: { message: "生年月を選択してください" }
   validates :birth_day,
     presence: { message: "生年日を選択してください" }
-  
-  def self.find_for_google_oauth2(auth)
-    user = User.where(email: auth.info.email).first
-    unless user
-      user = User.create(nickname:     auth.info.name,
-                         provider: auth.provider,
-                         uid:      auth.uid,
-                         email:    auth.info.email,
-                         password: Devise.friendly_token[0, 20])
-    end
-    user
-  end
 
   def self.find_for_oauth(auth)
     user = User.where(uid: auth.uid, provider: auth.provider).first
@@ -56,10 +44,9 @@ class User < ApplicationRecord
       user = User.create(
         uid:      auth.uid,
         provider: auth.provider,
+        nickname:     auth.info.name,
         email:    auth.info.email,
-        nickname:  auth.info.name,
-        password: Devise.friendly_token[0, 20],
-        
+        password: Devise.friendly_token[0, 20]
       )
     end
     user

--- a/app/views/devise/registrations/sns.html.haml
+++ b/app/views/devise/registrations/sns.html.haml
@@ -1,0 +1,88 @@
+.single-container.sign-up__profiles
+  = render partial: 'single-header'
+  %main.single-main.signup-page__header
+    %section.single-main__container
+      %h2.single-main__container__h2 会員情報入力
+      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "single-main__container__form"}) do |f|
+        .single-main__container__form__content
+          .form-group
+            = f.label :ニックネーム
+            %span.form-group__require 必須
+            = f.text_field :nickname, class: "form-group__input", placeholder: "例) メルカリ太郎", autofocus: "true"
+            - if resource.errors.messages[:nickname].present?
+              - resource.errors.messages[:nickname].each do |message|
+                %p.error= message
+          .form-group
+            = f.label :メールアドレス
+            %span.form-group__require 必須
+            = f.email_field :email, class: "form-group__input", placeholder: "PC・携帯どちらでも可", autofocus: "true", autocomplete: "email"
+            - if resource.errors.messages[:email].present?
+              - resource.errors.messages[:email].each do |message|
+                %p.error= message
+          .form-message
+            %h2 本人確認
+            %span 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+          .form-group
+            = f.label :姓（全角）
+            %span.form-group__require 必須
+            = f.text_field :family_name, class: "form-group__input", placeholder: "例) 山田", autofocus: "true"
+            - if resource.errors.messages[:family_name].present?
+              - resource.errors.messages[:family_name].each do |message|
+                %p.error= message
+          .form-group
+            = f.label :名（全角）
+            %span.form-group__require 必須
+            = f.text_field :last_name, class: "form-group__input", placeholder: "例) 彩", autofocus: "true"
+            - if resource.errors.messages[:last_name].present?
+              - resource.errors.messages[:last_name].each do |message|
+                %p.error= message
+          .form-group
+            = f.label :姓カナ（全角）
+            %span.form-group__require 必須
+            = f.text_field :family_name_kana, class: "form-group__input", placeholder: "例) ヤマダ", autofocus: "true"
+            - if resource.errors.messages[:family_name_kana].present?
+              - resource.errors.messages[:family_name_kana].each do |message|
+                %p.error= message
+          .form-group
+            = f.label :名カナ（全角）
+            %span.form-group__require 必須
+            = f.text_field :last_name_kana, class: "form-group__input", placeholder: "例) アヤ", autofocus: "true"
+            - if resource.errors.messages[:last_name_kana].present?
+              - resource.errors.messages[:last_name_kana].each do |message|
+                %p.error= message
+          .form-group
+            = f.label :生年月日
+            %span.form-group__require 必須
+            .select-wrap-birth
+              = f.select :birth_year, User.birth_years.keys, {prompt: '--'}, class: "select-wrap-birth__default"
+              %i.fas.fa-chevron-down.signup-profile-down
+              %span.form-group-name 年
+              = f.select :birth_month, User.birth_months.keys, {prompt: '--'}, class: "select-wrap-birth__default"
+              %i.fas.fa-chevron-down.signup-profile-down
+              %span.form-group-name 月
+              = f.select :birth_day, User.birth_days.keys, {prompt: '--'}, class: "select-wrap-birth__default"
+              %i.fas.fa-chevron-down.signup-profile-down
+              %span.form-group-name 日
+            - if resource.errors.messages[:birth_year].present?
+              - resource.errors.messages[:birth_year].each do |message|
+                %p.error= message
+            - if resource.errors.messages[:birth_month].present?
+              - resource.errors.messages[:birth_month].each do |message|
+                %p.error= message
+            - if resource.errors.messages[:birth_day].present?
+              - resource.errors.messages[:birth_day].each do |message|
+                %p.error= message
+            %span.form-message-bottom ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+          .form-group
+            .g-recaptcha.signup-recaptcha
+              -# TODO: reCAPTCHAの実装、現在は代替でイメージを表示
+              = image_tag "20190202205039.png", style: "width:100%;"
+          = f.hidden_field :password
+          = f.hidden_field :password_confirmation
+          = f.hidden_field :uid
+          = f.hidden_field :provider
+          .form-confirmation 「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします
+          .single-main__container__form__content
+            = f.submit "次へ進む", class: "single-main__container__form__content__btn"
+          .form-information 本人情報の登録について
+  = render partial: 'single-footer'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -8,8 +8,8 @@
       .login-panel__form-inner
         %button.single-main__container__inner__content__btn.btn-facebook
           %i.fab.fa-facebook-square
-          = link_to 'Facebookでログイン', user_facebook_omniauth_authorize_path
-        %button.single-main__container__inner__content__btn.btn-google= link_to 'Googleでログイン', user_google_oauth2_omniauth_authorize_path
+          = link_to 'Facebookでログイン', user_facebook_omniauth_authorize_path, method: :post
+        %button.single-main__container__inner__content__btn.btn-google= link_to 'Googleでログイン', user_google_oauth2_omniauth_authorize_path, method: :post
       = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
         .login-panel__form-inner
           .form-group

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -297,9 +297,9 @@ Devise.setup do |config|
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
   config.omniauth :google_oauth2,
-  Rails.application.secrets.google_client_id,
-  Rails.application.secrets.google_client_secret
-config.omniauth :facebook,
-  Rails.application.secrets.facebook_client_id,
-  Rails.application.secrets.facebook_client_secret
+    Rails.application.secrets.google_client_id,
+    Rails.application.secrets.google_client_secret
+  config.omniauth :facebook,
+    Rails.application.secrets.facebook_client_id,
+    Rails.application.secrets.facebook_client_secret
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,16 +1,19 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-    provider :google_oauth2,
-      Rails.application.secrets.google_client_id,
-      Rails.application.secrets.google_client_secret,
-      {
-  # ログイン後にGoogle Calendarのデータを取得したいので、scopeに
-  # https://www.googleapis.com/auth/calendarを記述しています。
-  # また、promptとaccess_typeを以下の設定にするとrefresh_tokenが得られる
-  # （その他の組み合わせは試していません）。
-        scope: "https://www.googleapis.com/auth/userinfo.email,
-                https://www.googleapis.com/auth/userinfo.profile,
-                https://www.googleapis.com/auth/calendar",
-        prompt: "select_account",
-        access_type: "offline"
-      }
-  end
+#   provider :facebook,
+#     Rails.application.secrets.facebook_client_id,
+#     Rails.application.secrets.facebook_client_secret,
+#     scope: 'email', display: 'popup', local: 'ja_JP', info_fields: "id, name"
+# end
+
+# Rails.application.config.middleware.use OmniAuth::Builder do
+#   provider :google_oauth2,
+#     Rails.application.secrets.google_client_id,
+#     Rails.application.secrets.google_client_secret,
+#     {
+#       scope: "https://www.googleapis.com/auth/userinfo.email,
+#               https://www.googleapis.com/auth/userinfo.profile,
+#               https://www.googleapis.com/auth/calendar",
+#       prompt: "select_account",
+#       access_type: "offline"
+#     }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,16 @@
 Rails.application.routes.draw do
 
   devise_for :users, controllers: { 
+                                    omniauth_callbacks: "users/omniauth_callbacks",
                                     registrations: "users/registrations",
                                     confirmations: "users/confirmations",
                                     sessions: "users/sessions",
-                                    passwords: "users/passwords",
-                                    omniauth_callbacks: "users/omniauth_callbacks"
+                                    passwords: "users/passwords"
                                   }
 
   devise_scope :user do
     get 'sms', to: 'users/registrations#sms'
+    get 'sns', to: 'users/registrations#sns'
   end
   
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,8 +81,6 @@ ActiveRecord::Schema.define(version: 20190621161701) do
     t.datetime "created_at",                                        null: false
     t.datetime "updated_at",                                        null: false
     t.string   "nickname"
-    t.string   "uid"
-    t.string   "provider"
     t.string   "family_name",                                       null: false
     t.string   "last_name",                                         null: false
     t.string   "family_name_kana",                                  null: false
@@ -91,6 +89,8 @@ ActiveRecord::Schema.define(version: 20190621161701) do
     t.string   "birth_month",                                       null: false
     t.string   "birth_day",                                         null: false
     t.text     "profile",                limit: 65535
+    t.string   "provider"
+    t.string   "uid"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
# WHAT
facebook,googleでのユーザー新規登録とログインができるようにした。

# WHY
新規登録、ログイン時にユーザーが行う手順を少なくすることにより、サイトのUXをあげるため。