### PR TITLE
パンくずリスト

### DIFF
--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -1,6 +1,14 @@
 *{
     text-decoration: none;
 }
+.breadcrumbs{
+    background-color: $white;
+    margin-top: 0;
+    border-top: 1px solid #eee;
+    display: block;
+    padding-left:160px;
+    font-size: 14px; 
+}
 header{
     height: 90px;
     background-color: $white;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'header'
+- breadcrumb :item, @item
+= render "layouts/breadcrumbs"
 %section.item-box
   %h1.item-box__h1
     = @item.name

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/users/addcard.html.haml
+++ b/app/views/users/addcard.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'header'
+- breadcrumb :addcard
+= render "layouts/breadcrumbs"
 %main
   = render partial: 'side-bar'
   .right-content-addcard

--- a/app/views/users/card.html.haml
+++ b/app/views/users/card.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'header'
+- breadcrumb :card
+= render "layouts/breadcrumbs"
 %main
   = render partial: 'side-bar'
   .right-content
@@ -9,7 +11,7 @@
         クレジットカード一覧
       .right-content-middle__btn
         = link_to addcard_users_path, class: "" do
-          支払い方法
+          クレジットカードを追加する
       .right-content-bottom
         = link_to "#", target: "_blank" do
           %span 支払い方法について

--- a/app/views/users/identification.html.haml
+++ b/app/views/users/identification.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'header'
+- breadcrumb :identification
+= render "layouts/breadcrumbs"
 %main
   = render partial: 'side-bar'
   .user-main

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'header'
+- breadcrumb :logout
+= render "layouts/breadcrumbs"
 %main
   = render partial: 'side-bar'
   .user-main

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'header'
+- breadcrumb :profile
+= render "layouts/breadcrumbs"
 %main
   = render partial: 'side-bar'
   .user-main

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'header'
+- breadcrumb :mypage
+= render "layouts/breadcrumbs"
 %main
   = render partial: 'side-bar'
   .user-main

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,60 @@
+  crumb :root do
+    link 'メルカリ', root_path
+  end
+
+# マイページヘのパンくずリスト
+  crumb :mypage do
+    link 'マイページ', user_path
+  end
+
+  crumb :profile do
+    link "マイページ › プロフィール", profile_users_path
+  end
+
+  crumb :card do
+    link "マイページ › 支払い方法", card_users_path
+  end
+
+  crumb :addcard do
+    link "クレジットカード情報入力", card_users_path
+    parent :card
+  end
+
+  crumb :identification do
+    link "マイページ › 本人情報", identification_users_path
+  end
+
+  crumb :logout do
+    link "マイページ › ログアウト", logout_users_path
+  end
+
+ # 商品詳細ページへのパンくずリスト
+  crumb :item do |item|
+    link "#{item.name}", item_path(item)
+    parent :root
+  end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
WHAT
マイページ内のページ遷移、商品詳細ページにパンくずリストを実装
WHY
ユーザーの居場所を明確に示すため